### PR TITLE
Planner app uses years and new scraped data + Minor Improvements

### DIFF
--- a/Code/courseai/degree/course_data_helper.py
+++ b/Code/courseai/degree/course_data_helper.py
@@ -5,7 +5,7 @@ from elasticsearch import Elasticsearch
 from elasticsearch_dsl import Search
 from elasticsearch_dsl.query import MultiMatch
 
-es_conn = Elasticsearch(['10.152.0.3'])
+es_conn = Elasticsearch(['localhost'])
 
 def get_data(code):
     global es_conn

--- a/Code/courseai/degree/course_data_helper.py
+++ b/Code/courseai/degree/course_data_helper.py
@@ -5,7 +5,7 @@ from elasticsearch import Elasticsearch
 from elasticsearch_dsl import Search
 from elasticsearch_dsl.query import MultiMatch
 
-es_conn = Elasticsearch(['localhost'])
+es_conn = Elasticsearch(['10.152.0.3'])
 
 def get_data(code):
     global es_conn

--- a/Code/courseai/static/css/style.css
+++ b/Code/courseai/static/css/style.css
@@ -81,6 +81,10 @@ body {
     width: 100%;
 }
 
+#degree-title-text a, #degree-title-text a:visited {
+    color: #0060cb
+}
+
 #confirm-reset-button {
     margin-right: auto;
 }
@@ -132,6 +136,7 @@ body {
     border: 1px solid #ced4da;
     border-radius: 0.25rem;
     background-color: white;
+    box-shadow: 0 0 0 #007bff; /* Need this to allow glow animation to work on first click */
 }
 
 .plan-cell:hover {
@@ -527,14 +532,25 @@ body {
     padding: 5px 0;
 }
 
-.chat_head, .msg_head {
-    background: #f39c12;
+.msg_head {
+    background: #3498db;
     color: white;
     padding: .35rem .7rem;
     font-weight: bold;
     cursor: pointer;
     border-radius: 5px 5px 0 0;
     text-shadow: 0 -1px 0 #6f6f6f;
+}
+
+.msg_head .arrow:before {
+    font-family: 'Font Awesome\ 5 Free';
+    float: right;
+    content: "\f078";
+    text-shadow: 0 -1px 0 #6f6f6f;
+}
+
+.msg_head.chatbox-collapsed .arrow:before {
+    content: "\f077";
 }
 
 .msg_box {
@@ -546,10 +562,6 @@ body {
     /*border: 1px solid #b9b9b9;*/
     border-radius: 5px 5px 0 0;
     z-index: 100;
-}
-
-.msg_head {
-    background: #3498db;
 }
 
 .msg_body {

--- a/Code/courseai/static/js/chatbox.js
+++ b/Code/courseai/static/js/chatbox.js
@@ -7,17 +7,20 @@ $(document).ready(function () {
     });
     let lexruntime = new AWS.LexRuntime();
 
-    $('.chat_head').click(function () {
-        $('.chat_body').slideToggle('slow');
-    });
 
     $('.msg_head').click(function () {
         $('.msg_wrap').slideToggle('slow');
+        const msg_head = $('.msg_head');
+        const collapsed_class = 'chatbox-collapsed';
+        if (msg_head.hasClass(collapsed_class)) {
+            msg_head.removeClass(collapsed_class);
+        } else msg_head.addClass(collapsed_class);
     });
 
-    $('.close').click(function () {
-        $('.msg_box').hide();
-    });
+    // Close function, not used.
+    /* $('.close').click(function () {
+           $('.msg_box').hide();
+       }); */
 
     const msg_input = $('.msg_input');
     autosize(msg_input);

--- a/Code/courseai/static/js/planner_app/data.js
+++ b/Code/courseai/static/js/planner_app/data.js
@@ -152,15 +152,23 @@ async function batchMMSData(mms_actions) {
 async function getDegreeOffering(code, year) {
     if (!(code in KNOWN_DEGREES)) KNOWN_DEGREES[code] = {};
     if (!(year in KNOWN_DEGREES[code])) {
-        await $.ajax({
-            url: 'degree/degreereqs',
-            data: {'query': code},
-            success: function (data) {
-                if (!code in KNOWN_DEGREES) KNOWN_DEGREES[code] = {};
-                KNOWN_DEGREES[code][year] = new Degree(code, year, data.name, data.units, data.required);
-                //TODO: Support for Optional Rule Sections
-            }
-        });
+        try {
+            await $.ajax({
+                url: 'degree/degreereqs',
+                data: {'query': code + '-' + year},
+                success: function (data) {
+                    if (!code in KNOWN_DEGREES) KNOWN_DEGREES[code] = {};
+                    KNOWN_DEGREES[code][year] = new Degree(code, year, data.name, data.units, data.required);
+                    //TODO: Support for Optional Rule Sections
+                },
+                error: function () {
+                    KNOWN_DEGREES[code][year] = new Degree(code, year, degree_name, 144, {});
+                    console.log('Failed to retrieve degree program requirements for ' + code + '-' + year);
+                }
+            });
+        } catch (error) {
+            console.log(error);
+        }
         await $.ajax({
             url: 'degree/degreeplan',
             data: {

--- a/Code/courseai/static/js/planner_app/degree.js
+++ b/Code/courseai/static/js/planner_app/degree.js
@@ -64,7 +64,7 @@ function Degree(code, year, title, units, rules, suggestedPlan = {}) {
                     let section_sat = true;
                     if (type === "compulsory_courses") section_sat = matches.length === section.length;
                     if (type === "one_from_here") section_sat = matches.length >= 1;
-                    if (type === "x_from_here") section_sat = section_units >= section.num;
+                    if (type === "x_from_here") section_sat = section_units >= (section.num || section.units);
                     overall_sat = overall_sat && section_sat;
                     rule_details.push({'type': type, 'sat': section_sat, 'units': section_units, 'codes': section_codes});
                 }

--- a/Code/courseai/templates/dynamic_pages/chatbox.html
+++ b/Code/courseai/templates/dynamic_pages/chatbox.html
@@ -1,0 +1,14 @@
+<div class="msg_box" style="right: 1%">
+    <div class="msg_head">
+        <div class="arrow"></div>
+        Ask a Question
+    </div>
+    <div class="msg_wrap">
+        <div class="msg_body">
+            <div class="msg_a">Hi, how can I help you today?</div>
+            <div class="msg_push"></div>
+        </div>
+        <div class="msg_footer"><textarea class="msg_input form-control form-control-plaintext" rows="1"></textarea>
+        </div>
+    </div>
+</div>

--- a/Code/courseai/templates/dynamic_pages/index.html
+++ b/Code/courseai/templates/dynamic_pages/index.html
@@ -6,6 +6,8 @@
     <meta charset="UTF-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <link rel="stylesheet" href="{% static "css/bootstrap.min.css" %}"/>
+    <link rel="stylesheet" href="{% static "css/solid.css" %}"/>
+    <link rel="stylesheet" href="{% static "css/fontawesome.css" %}"/>
     <link rel="stylesheet" href="{% static "css/style.css" %}"/>
     <title>Degree Builder</title>
 </head>
@@ -74,19 +76,7 @@
     Scarlett Qin, Thien Bui-Nguyen
 </div>
 
-<div class="msg_box" style="right: 1%">
-    <div class="msg_head">Ask a Question
-        <div class="close">&times;</div>
-    </div>
-    <div class="msg_wrap">
-        <div class="msg_body">
-            <div class="msg_a">Hi, how can I help you today?</div>
-            <div class="msg_push"></div>
-        </div>
-        <div class="msg_footer"><textarea class="msg_input form-control form-control-plaintext" rows="1"></textarea>
-        </div>
-    </div>
-</div>
+{% include "dynamic_pages/chatbox.html" %}
 
 <script src="{% static "js/jquery.min.js" %}"></script>
 <script src="{% static "js/popper.min.js" %}"></script>

--- a/Code/courseai/templates/dynamic_pages/planner.html
+++ b/Code/courseai/templates/dynamic_pages/planner.html
@@ -261,19 +261,9 @@
         </div>
     </div>
 </div>
-<div class="msg_box">
-    <div class="msg_head">Ask a Question
-        <div class="close">&times;</div>
-    </div>
-    <div class="msg_wrap">
-        <div class="msg_body">
-            <div class="msg_a">Hi, how can I help you today?</div>
-            <div class="msg_push"></div>
-        </div>
-        <div class="msg_footer"><textarea class="msg_input form-control form-control-plaintext" rows="1"></textarea>
-        </div>
-    </div>
-</div>
+
+{% include "dynamic_pages/chatbox.html" %}
+
 <script src="{% static "js/jquery.min.js" %}"></script>
 <script src="{% static "js/popper.min.js" %}"></script>
 <script src="{% static "js/bootstrap.min.js" %}"></script>


### PR DESCRIPTION
## Planner app uses years and new scraped data
* Planner app requests degree requirements of the specified year.
* When the requirements are unavailable the app still loads, just without the degree progress tracker.

## Minor improvements: https://trello.com/c/7mxap6j7
* Changed the × on the chatbox to a minimisation button with down/up arrows.
* Made the degree title link to P&C, in a new window/tab.
* Suppressed 'fly-back' animation when courses are dragged and added successfully.
* Reset/Clear courses button is visible always.
* Clicking a course's warning link will scroll down to the course within the plan.
* Clicking this warning link also correctly displays the blue outline glow on the first click.
* Moved chatbox HTML to a template.
* Fixed 'Clear Courses' not updating the progress trackers. 